### PR TITLE
fix: use container-internal ports for CONVEX_*_ORIGIN in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     volumes:
       - ./out/data:/convex/data
     environment:
-      - CONVEX_CLOUD_ORIGIN=http://localhost:${CONVEX_BACKEND_PORT:?missing CONVEX_BACKEND_PORT}
-      - CONVEX_SITE_ORIGIN=http://localhost:${SITE_PROXY_PORT:?missing SITE_PROXY_PORT}
+      - CONVEX_CLOUD_ORIGIN=http://localhost:3210
+      - CONVEX_SITE_ORIGIN=http://localhost:3211
       - INSTANCE_NAME=${INSTANCE_NAME:?missing INSTANCE_NAME}
       - INSTANCE_SECRET=${INSTANCE_SECRET:?missing INSTANCE_SECRET}
       - DISABLE_BEACON=true


### PR DESCRIPTION
## Summary

- **Root cause**: `CONVEX_CLOUD_ORIGIN` and `CONVEX_SITE_ORIGIN` in `docker-compose.yml` used host-mapped ports (e.g. `localhost:13211`), which are unreachable from inside the Docker container. The Convex backend failed to fetch its own JWKS for JWT verification, causing every server-side session check to return null and redirect authenticated users back to `/auth/login`.
- **Fix**: Use the container-internal ports (`localhost:3210` and `localhost:3211`) that the Convex backend and site proxy actually listen on inside the container.
- **Browser-facing URLs** (`PUBLIC_CONVEX_URL`, `PUBLIC_CONVEX_SITE_URL`) remain unchanged — they correctly use host-mapped ports since they're accessed from the host.

Closes #16

## Test plan

- [x] Verified JWKS endpoint is reachable inside container at `localhost:3211` (`curl` from inside the container)
- [x] Verified JWKS is NOT reachable at `localhost:13211` from inside the container (confirming the bug)
- [x] Login flow tested end-to-end with Playwright: sign in → select tenant → workspace dashboard
- [x] All 15 E2E tests pass (`bun run test:e2e`)
- [x] All passing unit tests still pass (1 pre-existing failure in `init.test.ts` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)