### PR TITLE
chore: route all playwright-cli outputs to out/playwright/

### DIFF
--- a/.agents/skills/playwright-cli/SKILL.md
+++ b/.agents/skills/playwright-cli/SKILL.md
@@ -18,7 +18,7 @@ playwright-cli click e15
 playwright-cli type "page.click"
 playwright-cli press Enter
 # take a screenshot (rarely used, as snapshot is more common)
-playwright-cli screenshot
+playwright-cli screenshot --filename=out/playwright/screenshots/page.png
 # close the browser
 playwright-cli close
 ```
@@ -86,11 +86,12 @@ playwright-cli mousewheel 0 100
 
 ### Save as
 
+Always save generated files to `out/playwright/<type>/` so they are gitignored and easy to find.
+
 ```bash
-playwright-cli screenshot
-playwright-cli screenshot e5
-playwright-cli screenshot --filename=page.png
-playwright-cli pdf --filename=page.pdf
+playwright-cli screenshot --filename=out/playwright/screenshots/page.png
+playwright-cli screenshot e5 --filename=out/playwright/screenshots/element.png
+playwright-cli pdf --filename=out/playwright/pdfs/page.pdf
 ```
 
 ### Tabs
@@ -108,8 +109,8 @@ playwright-cli tab-select 0
 
 ```bash
 playwright-cli state-save
-playwright-cli state-save auth.json
-playwright-cli state-load auth.json
+playwright-cli state-save out/playwright/state/auth.json
+playwright-cli state-load out/playwright/state/auth.json
 
 # Cookies
 playwright-cli cookie-list
@@ -155,7 +156,7 @@ playwright-cli run-code "async page => await page.context().grantPermissions(['g
 playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
-playwright-cli video-start video.webm
+playwright-cli video-start out/playwright/videos/video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop
 ```
@@ -228,7 +229,7 @@ You can also take a snapshot on demand using `playwright-cli snapshot` command. 
 playwright-cli snapshot
 
 # save to file, use when snapshot is a part of the workflow result
-playwright-cli snapshot --filename=after-click.yaml
+playwright-cli snapshot --filename=out/playwright/snapshots/after-click.yaml
 
 # snapshot an element instead of the whole page
 playwright-cli snapshot "#main"

--- a/.agents/skills/playwright-cli/references/running-code.md
+++ b/.agents/skills/playwright-cli/references/running-code.md
@@ -125,7 +125,7 @@ playwright-cli run-code "async page => {
   const downloadPromise = page.waitForEvent('download');
   await page.getByRole('link', { name: 'Download' }).click();
   const download = await downloadPromise;
-  await download.saveAs('./downloaded-file.pdf');
+  await download.saveAs('out/playwright/downloads/downloaded-file.pdf');
   return download.suggestedFilename();
 }"
 ```
@@ -214,7 +214,7 @@ playwright-cli run-code "async page => {
   await page.getByRole('textbox', { name: 'Password' }).fill('secret');
   await page.getByRole('button', { name: 'Sign in' }).click();
   await page.waitForURL('**/dashboard');
-  await page.context().storageState({ path: 'auth.json' });
+  await page.context().storageState({ path: 'out/playwright/state/auth.json' });
   return 'Login successful';
 }"
 

--- a/.agents/skills/playwright-cli/references/session-management.md
+++ b/.agents/skills/playwright-cli/references/session-management.md
@@ -90,8 +90,8 @@ playwright-cli -s=variant-a open "https://app.com?variant=a"
 playwright-cli -s=variant-b open "https://app.com?variant=b"
 
 # Compare
-playwright-cli -s=variant-a screenshot
-playwright-cli -s=variant-b screenshot
+playwright-cli -s=variant-a screenshot --filename=out/playwright/screenshots/variant-a.png
+playwright-cli -s=variant-b screenshot --filename=out/playwright/screenshots/variant-b.png
 ```
 
 ### Persistent Profile

--- a/.agents/skills/playwright-cli/references/storage-state.md
+++ b/.agents/skills/playwright-cli/references/storage-state.md
@@ -13,14 +13,14 @@ Save and restore complete browser state including cookies and storage.
 playwright-cli state-save
 
 # Save to specific filename
-playwright-cli state-save my-auth-state.json
+playwright-cli state-save out/playwright/state/my-auth-state.json
 ```
 
 ### Restore Storage State
 
 ```bash
 # Load storage state from file
-playwright-cli state-load my-auth-state.json
+playwright-cli state-load out/playwright/state/my-auth-state.json
 
 # Reload page to apply cookies
 playwright-cli open https://example.com
@@ -240,10 +240,10 @@ playwright-cli fill e2 "password123"
 playwright-cli click e3
 
 # Save the authenticated state
-playwright-cli state-save auth.json
+playwright-cli state-save out/playwright/state/auth.json
 
 # Step 2: Later, restore state and skip login
-playwright-cli state-load auth.json
+playwright-cli state-load out/playwright/state/auth.json
 playwright-cli open https://app.example.com/dashboard
 # Already logged in!
 ```
@@ -256,12 +256,12 @@ playwright-cli open https://example.com
 playwright-cli eval "() => { document.cookie = 'session=abc123'; localStorage.setItem('user', 'john'); }"
 
 # Save state to file
-playwright-cli state-save my-session.json
+playwright-cli state-save out/playwright/state/my-session.json
 
 # ... later, in a new session ...
 
 # Restore state
-playwright-cli state-load my-session.json
+playwright-cli state-load out/playwright/state/my-session.json
 playwright-cli open https://example.com
 # Cookies and localStorage are restored!
 ```
@@ -269,7 +269,7 @@ playwright-cli open https://example.com
 ## Security Notes
 
 - Never commit storage state files containing auth tokens
-- Add `*.auth-state.json` to `.gitignore`
+- Save state files under `out/playwright/state/` (gitignored via `out/`)
 - Delete state files after automation completes
 - Use environment variables for sensitive data
 - By default, sessions run in-memory mode which is safer for sensitive operations

--- a/.agents/skills/playwright-cli/references/tracing.md
+++ b/.agents/skills/playwright-cli/references/tracing.md
@@ -132,7 +132,7 @@ Traces can consume significant disk space:
 
 ```bash
 # Remove traces older than 7 days
-find .playwright-cli/traces -mtime +7 -delete
+find out/playwright/traces -mtime +7 -delete
 ```
 
 ## Limitations

--- a/.agents/skills/playwright-cli/references/video-recording.md
+++ b/.agents/skills/playwright-cli/references/video-recording.md
@@ -9,7 +9,7 @@ Capture browser automation sessions as video for debugging, documentation, or ve
 playwright-cli open
 
 # Start recording
-playwright-cli video-start demo.webm
+playwright-cli video-start out/playwright/videos/demo.webm
 
 # Add a chapter marker for section transitions
 playwright-cli video-chapter "Getting Started" --description="Opening the homepage" --duration=2000
@@ -33,8 +33,8 @@ playwright-cli video-stop
 
 ```bash
 # Include context in filename
-playwright-cli video-start recordings/login-flow-2024-01-15.webm
-playwright-cli video-start recordings/checkout-test-run-42.webm
+playwright-cli video-start out/playwright/videos/login-flow-2024-01-15.webm
+playwright-cli video-start out/playwright/videos/checkout-test-run-42.webm
 ```
 
 ### 2. Record entire hero scripts.
@@ -50,7 +50,7 @@ It allows pulling appropriate pauses between the actions and annotating the vide
 
 ```js
 async (page) => {
-  await page.screencast.start({ path: 'video.webm', size: { width: 1280, height: 800 } });
+  await page.screencast.start({ path: 'out/playwright/videos/video.webm', size: { width: 1280, height: 800 } });
   await page.goto('https://demo.playwright.dev/todomvc');
 
   // Show a chapter card — blurs the page and shows a dialog.


### PR DESCRIPTION
## Summary
- All playwright-cli generated files (screenshots, PDFs, videos, traces, state, snapshots, downloads) now output to `out/playwright/<type>/` subdirectories
- Updated examples across `SKILL.md` and all reference files (`session-management`, `tracing`, `video-recording`, `storage-state`, `running-code`)
- Leverages existing `out/` gitignore entry to keep generated artifacts out of version control

## Test plan
- [x] Verify `out/` is in `.gitignore`
- [x] Review all code examples in the skill and references for consistent `out/playwright/` paths
- [x] Run `playwright-cli screenshot --filename=out/playwright/screenshots/test.png` and confirm file is created at the expected path

🤖 Generated with [Claude Code](https://claude.com/claude-code)