### PR TITLE
fix: detect port conflicts and add --auto mode to generate-ports

### DIFF
--- a/docs/docker-setup.md
+++ b/docs/docker-setup.md
@@ -56,10 +56,11 @@ Re-running always regenerates all values. If `INSTANCE_NAME` or `INSTANCE_SECRET
 ### 2. Generate ports
 
 ```sh
-bun scripts/generate-ports.ts --offset <N>
+bun scripts/generate-ports.ts --auto
 ```
 
-Computes port assignments and derived URLs, appends them to `.env`:
+Automatically finds the first available port offset (in steps of 10,000) by probing the host for
+occupied ports. Writes port assignments and derived URLs to `.env`:
 
 - `CONVEX_BACKEND_PORT` = 3210 + offset
 - `SITE_PROXY_PORT` = 3211 + offset
@@ -70,8 +71,9 @@ Computes port assignments and derived URLs, appends them to `.env`:
 - `PUBLIC_CONVEX_SITE_URL` = `http://localhost:<SITE_PROXY_PORT>`
 - `PUBLIC_SITE_URL` = `http://localhost:<VITE_PORT>`
 
-The `--offset` argument is required (0 is permitted). Each agent on the same machine should use a
-different offset to avoid port collisions.
+You can also specify an explicit offset with `--offset <N>` (0 is permitted). The script checks
+port availability and fails fast if any port is already in use. Prefer `--auto` for multi-agent
+setups — it handles offset coordination automatically.
 
 ### 3. Start the backend stack
 
@@ -133,20 +135,16 @@ Then restart Vite to pick up the correct values.
 
 ## Port isolation
 
-Multiple agents on the same machine each use a different `--offset`:
+Multiple agents on the same machine each run `--auto` to get a conflict-free offset:
 
 ```sh
-# Agent 1
-bun scripts/generate-ports.ts --offset 0     # ports 3210, 3211, 6791, 5173
-
-# Agent 2
-bun scripts/generate-ports.ts --offset 10000  # ports 13210, 13211, 16791, 15173
-
-# Agent 3
-bun scripts/generate-ports.ts --offset 20000  # ports 23210, 23211, 26791, 25173
+# Each agent — --auto finds the first free offset automatically
+bun scripts/generate-ports.ts --auto
 ```
 
 Each agent runs in its own worktree with its own `.env` and its own `docker compose up`.
+The `--auto` flag probes the host for occupied ports and picks the first available offset
+(0, 10000, 20000, …), so agents don't need to coordinate manually.
 
 ## Environment variable flow
 

--- a/scripts/generate-ports.ts
+++ b/scripts/generate-ports.ts
@@ -1,21 +1,18 @@
 #!/usr/bin/env bun
 import { resolve } from 'node:path';
-import { merge } from './lib/dotenv.ts';
-
-const BASE_PORTS = {
-  CONVEX_BACKEND_PORT: 3210,
-  SITE_PROXY_PORT: 3211,
-  DASHBOARD_PORT: 6791,
-  VITE_PORT: 5173,
-} as const;
+import { generatePorts } from './lib/ports.ts';
 
 const ENV_PATH = resolve(import.meta.dirname, '..', '.env');
 
-function parseOffset(): number {
+function parseArgs(): { mode: 'offset'; offset: number } | { mode: 'auto' } {
+  if (process.argv.includes('--auto')) return { mode: 'auto' };
+
   const offsetIndex = process.argv.indexOf('--offset');
   if (offsetIndex === -1 || offsetIndex + 1 >= process.argv.length) {
     console.error('Usage: bun scripts/generate-ports.ts --offset <N>');
-    console.error('  <N>  non-negative integer port offset (0 is permitted)');
+    console.error('       bun scripts/generate-ports.ts --auto');
+    console.error('  --offset <N>  non-negative integer port offset (0 is permitted)');
+    console.error('  --auto        automatically find the first available offset');
     process.exit(1);
   }
 
@@ -26,31 +23,27 @@ function parseOffset(): number {
     process.exit(1);
   }
 
-  return offset;
+  return { mode: 'offset', offset };
 }
 
-function computePorts(offset: number): Record<string, string> {
-  const entries: Record<string, string> = {};
-  for (const [key, base] of Object.entries(BASE_PORTS)) {
-    entries[key] = String(base + offset);
-  }
-  return entries;
-}
+async function main() {
+  const args = parseArgs();
 
-function main() {
-  const offset = parseOffset();
-  const entries = computePorts(offset);
+  try {
+    const { offset, entries } = await generatePorts(
+      args.mode === 'auto'
+        ? { mode: 'auto', envPath: ENV_PATH }
+        : { mode: 'offset', offset: args.offset, envPath: ENV_PATH },
+    );
 
-  entries.CONVEX_SELF_HOSTED_URL = `http://localhost:${entries.CONVEX_BACKEND_PORT}`;
-  entries.PUBLIC_CONVEX_URL = `http://localhost:${entries.CONVEX_BACKEND_PORT}`;
-  entries.PUBLIC_CONVEX_SITE_URL = `http://localhost:${entries.SITE_PROXY_PORT}`;
-  entries.PUBLIC_SITE_URL = `http://localhost:${entries.VITE_PORT}`;
-
-  merge(ENV_PATH, entries);
-
-  console.log('Wrote port variables to .env:');
-  for (const [key, value] of Object.entries(entries)) {
-    console.log(`  ${key}=${value}`);
+    if (args.mode === 'auto') console.log(`Selected offset: ${offset}`);
+    console.log('Wrote port variables to .env:');
+    for (const [key, value] of Object.entries(entries)) {
+      console.log(`  ${key}=${value}`);
+    }
+  } catch (error) {
+    console.error(`Error: ${error instanceof Error ? error.message : error}`);
+    process.exit(1);
   }
 }
 

--- a/scripts/lib/ports.test.ts
+++ b/scripts/lib/ports.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment node
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+import { checkPorts, computePorts, findAvailableOffset, generatePorts, isPortAvailable, OFFSET_STEP } from './ports.ts';
+
+describe('computePorts', () => {
+  test('offset 0 returns base ports', () => {
+    const ports = computePorts(0);
+    expect(ports).toEqual({
+      CONVEX_BACKEND_PORT: 3210,
+      SITE_PROXY_PORT: 3211,
+      DASHBOARD_PORT: 6791,
+      VITE_PORT: 5173,
+    });
+  });
+
+  test('offset shifts all ports by the given amount', () => {
+    const ports = computePorts(10000);
+    expect(ports).toEqual({
+      CONVEX_BACKEND_PORT: 13210,
+      SITE_PROXY_PORT: 13211,
+      DASHBOARD_PORT: 16791,
+      VITE_PORT: 15173,
+    });
+  });
+});
+
+describe('isPortAvailable', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+  });
+
+  test('returns true for a free port', async () => {
+    const freePort = await new Promise<number>((resolve, reject) => {
+      const s = createServer();
+      s.listen(0, '0.0.0.0', () => {
+        const addr = s.address();
+        if (!addr || typeof addr === 'string') return reject(new Error('no address'));
+        const port = addr.port;
+        s.close(() => resolve(port));
+      });
+    });
+
+    expect(await isPortAvailable(freePort)).toBe(true);
+  });
+
+  test('returns false for a port already in use', async () => {
+    server = createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+      server!.on('error', reject);
+      server!.listen(0, '0.0.0.0', () => {
+        const addr = server!.address();
+        if (!addr || typeof addr === 'string') return reject(new Error('no address'));
+        resolve(addr.port);
+      });
+    });
+
+    expect(await isPortAvailable(port)).toBe(false);
+  });
+});
+
+describe('checkPorts', () => {
+  let servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    );
+    servers = [];
+  });
+
+  function bindPort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const s = createServer();
+      s.on('error', reject);
+      s.listen(0, '0.0.0.0', () => {
+        const addr = s.address();
+        if (!addr || typeof addr === 'string') return reject(new Error('no address'));
+        servers.push(s);
+        resolve(addr.port);
+      });
+    });
+  }
+
+  test('returns no conflicts when all ports are free', async () => {
+    const result = await checkPorts({ A: 0, B: 0 });
+    expect(result.conflicts).toEqual([]);
+  });
+
+  test('returns conflicting port numbers when ports are occupied', async () => {
+    const occupied = await bindPort();
+    const result = await checkPorts({ A: occupied, B: 0 });
+    expect(result.conflicts).toContain(occupied);
+  });
+});
+
+describe('findAvailableOffset', () => {
+  let servers: Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    );
+    servers = [];
+  });
+
+  function bindSpecificPort(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const s = createServer();
+      s.on('error', reject);
+      s.listen(port, '0.0.0.0', () => {
+        servers.push(s);
+        resolve();
+      });
+    });
+  }
+
+  test('skips offsets whose ports are occupied', async () => {
+    const testStart = 40_000;
+    const blockedPort = 3210 + testStart;
+    await bindSpecificPort(blockedPort);
+
+    const offset = await findAvailableOffset({ startOffset: testStart });
+    expect(offset).not.toBe(testStart);
+    expect(offset % OFFSET_STEP).toBe(0);
+  });
+
+  test('returns startOffset when its ports are all free', async () => {
+    const offset = await findAvailableOffset({ startOffset: 50_000 });
+    expect(offset).toBe(50_000);
+  });
+});
+
+describe('generatePorts', () => {
+  let tmpDir: string;
+  let envPath: string;
+  let servers: Server[] = [];
+
+  function bindSpecificPort(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const s = createServer();
+      s.on('error', reject);
+      s.listen(port, '0.0.0.0', () => {
+        servers.push(s);
+        resolve();
+      });
+    });
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))),
+    );
+    servers = [];
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function setup(existingEnv?: string) {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ports-test-'));
+    envPath = join(tmpDir, '.env');
+    if (existingEnv) writeFileSync(envPath, existingEnv);
+  }
+
+  test('--offset writes ports and derived URLs to .env', async () => {
+    setup();
+    await generatePorts({ mode: 'offset', offset: 40_000, envPath });
+
+    const content = readFileSync(envPath, 'utf8');
+    expect(content).toContain('CONVEX_BACKEND_PORT=43210');
+    expect(content).toContain('PUBLIC_CONVEX_URL=http://localhost:43210');
+  });
+
+  test('--offset rejects occupied ports', async () => {
+    setup();
+    await bindSpecificPort(43210);
+
+    await expect(generatePorts({ mode: 'offset', offset: 40_000, envPath })).rejects.toThrow(
+      /43210/,
+    );
+  });
+
+  test('--auto finds a free offset and writes to .env', async () => {
+    setup();
+    const result = await generatePorts({ mode: 'auto', envPath, startOffset: 40_000 });
+
+    const content = readFileSync(envPath, 'utf8');
+    expect(content).toContain('CONVEX_BACKEND_PORT=');
+    expect(result.offset).toBe(40_000);
+  });
+
+  test('--auto skips occupied offsets', async () => {
+    setup();
+    await bindSpecificPort(43210);
+
+    const result = await generatePorts({ mode: 'auto', envPath, startOffset: 40_000 });
+    expect(result.offset).not.toBe(40_000);
+  });
+
+  test('preserves existing .env entries', async () => {
+    setup('INSTANCE_NAME=my-instance\nINSTANCE_SECRET=abc123\n');
+    await generatePorts({ mode: 'offset', offset: 40_000, envPath });
+
+    const content = readFileSync(envPath, 'utf8');
+    expect(content).toContain('INSTANCE_NAME=my-instance');
+    expect(content).toContain('CONVEX_BACKEND_PORT=43210');
+  });
+});

--- a/scripts/lib/ports.ts
+++ b/scripts/lib/ports.ts
@@ -1,0 +1,89 @@
+import { createServer } from 'node:net';
+import { merge } from './dotenv.ts';
+
+export const BASE_PORTS = {
+  CONVEX_BACKEND_PORT: 3210,
+  SITE_PROXY_PORT: 3211,
+  DASHBOARD_PORT: 6791,
+  VITE_PORT: 5173,
+} as const;
+
+export const OFFSET_STEP = 10_000;
+
+export function computePorts(offset: number): Record<string, number> {
+  const entries: Record<string, number> = {};
+  for (const [key, base] of Object.entries(BASE_PORTS)) {
+    entries[key] = base + offset;
+  }
+  return entries;
+}
+
+export async function checkPorts(
+  ports: Record<string, number>,
+): Promise<{ conflicts: number[] }> {
+  const values = Object.values(ports).filter((p) => p > 0);
+  const results = await Promise.all(values.map((p) => isPortAvailable(p).then((ok) => ({ port: p, ok }))));
+  return { conflicts: results.filter((r) => !r.ok).map((r) => r.port) };
+}
+
+const MAX_OFFSET = 50_000;
+
+export async function findAvailableOffset(
+  opts?: { startOffset?: number },
+): Promise<number> {
+  const start = opts?.startOffset ?? 0;
+  for (let offset = start; offset <= MAX_OFFSET; offset += OFFSET_STEP) {
+    const ports = computePorts(offset);
+    const { conflicts } = await checkPorts(ports);
+    if (conflicts.length === 0) return offset;
+  }
+  throw new Error(
+    `No available port offset found (tried ${start}–${MAX_OFFSET} in steps of ${OFFSET_STEP})`,
+  );
+}
+
+type GeneratePortsOpts =
+  | { mode: 'offset'; offset: number; envPath: string }
+  | { mode: 'auto'; envPath: string; startOffset?: number };
+
+export async function generatePorts(
+  opts: GeneratePortsOpts,
+): Promise<{ offset: number; entries: Record<string, string> }> {
+  let offset: number;
+  if (opts.mode === 'offset') {
+    offset = opts.offset;
+    const ports = computePorts(offset);
+    const { conflicts } = await checkPorts(ports);
+    if (conflicts.length > 0) {
+      throw new Error(
+        `Port conflict: ${conflicts.join(', ')} already in use. Choose a different offset or use --auto.`,
+      );
+    }
+  } else {
+    offset = await findAvailableOffset({ startOffset: opts.startOffset });
+  }
+
+  const ports = computePorts(offset);
+  const entries: Record<string, string> = {};
+  for (const [key, value] of Object.entries(ports)) {
+    entries[key] = String(value);
+  }
+  entries.CONVEX_SELF_HOSTED_URL = `http://localhost:${entries.CONVEX_BACKEND_PORT}`;
+  entries.PUBLIC_CONVEX_URL = `http://localhost:${entries.CONVEX_BACKEND_PORT}`;
+  entries.PUBLIC_CONVEX_SITE_URL = `http://localhost:${entries.SITE_PROXY_PORT}`;
+  entries.PUBLIC_SITE_URL = `http://localhost:${entries.VITE_PORT}`;
+
+  merge(opts.envPath, entries);
+  return { offset, entries };
+}
+
+export function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', () => resolve(false));
+    server.listen(port, '0.0.0.0', () => {
+      server.close(() => resolve(true));
+    });
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
   test: {
     environment: 'edge-runtime',
     server: { deps: { inline: ['convex-test'] } },
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     passWithNoTests: true,
   },
 });


### PR DESCRIPTION
## Summary

- `generate-ports.ts` now probes host ports before writing to `.env` — fails fast with a clear error listing conflicting ports instead of silently writing occupied ports
- New `--auto` flag iterates candidate offsets (0, 10k, 20k, …) and picks the first one with all ports free — agents no longer need to coordinate offsets manually
- Port availability probe binds on `0.0.0.0` to catch Docker container bindings (which don't show up on `127.0.0.1`)
- Port logic extracted into `scripts/lib/ports.ts` for reuse and testability

Closes #17

## Test plan

- [x] 13 unit tests covering: `computePorts`, `isPortAvailable`, `checkPorts`, `findAvailableOffset`, `generatePorts` (offset mode, auto mode, conflict detection, .env preservation)
- [x] Verified `--offset 0` fails against live Docker containers on offset 0
- [x] Verified `--auto` correctly skips occupied offsets (0, 10k, 20k, 30k) and selects 40k
- [x] Existing test suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)