### PR TITLE
feat: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` for automated dependency updates
- Tracks two ecosystems: `npm` (Bun/Node deps) and `github-actions` (workflow action versions)
- Monthly schedule, minor+patch updates grouped into single PRs, 5 open PR limit
- Security updates are immediate regardless of schedule (Dependabot default)

## Acceptance criteria

- [x] `.github/dependabot.yml` exists and is valid YAML
- [x] npm ecosystem configured with monthly schedule
- [x] github-actions ecosystem configured with monthly schedule
- [x] Minor and patch updates grouped per ecosystem
- [x] PR limit set to 5
- [ ] Dependabot tab in GitHub repo settings shows both ecosystems active after merge

## Test plan

- [x] YAML validated locally
- [ ] Verify Dependabot activates after merge to main

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)