### PR TITLE
fix: tenant picker navigation fails with stale Convex JWT

### DIFF
--- a/src/convex/betterAuth/_generated/component.ts
+++ b/src/convex/betterAuth/_generated/component.ts
@@ -117,7 +117,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -156,7 +155,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -196,7 +194,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -229,7 +226,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -261,7 +257,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -314,7 +309,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -353,7 +347,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -393,7 +386,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -426,7 +418,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -458,7 +449,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -506,7 +496,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           where?: Array<{
             connector?: "AND" | "OR";
             field: string;
-            mode?: "sensitive" | "insensitive";
             operator?:
               | "lt"
               | "lte"
@@ -541,7 +530,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           where?: Array<{
             connector?: "AND" | "OR";
             field: string;
-            mode?: "sensitive" | "insensitive";
             operator?:
               | "lt"
               | "lte"
@@ -593,7 +581,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -645,7 +632,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -699,7 +685,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -739,7 +724,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -777,7 +761,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -839,7 +822,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -891,7 +873,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -945,7 +926,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -985,7 +965,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -1023,7 +1002,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"

--- a/src/routes/app/+layout.server.ts
+++ b/src/routes/app/+layout.server.ts
@@ -13,4 +13,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
     const next = encodeURIComponent(url.pathname + url.search);
     redirect(303, `/auth/login?next=${next}`);
   }
+
+  if (!locals.session.tenantId) {
+    redirect(303, '/auth/select-tenant');
+  }
 };

--- a/src/routes/auth/select-tenant/+page.server.ts
+++ b/src/routes/auth/select-tenant/+page.server.ts
@@ -1,7 +1,7 @@
-import { redirect } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import { createConvexHttpClient } from '@mmailaender/convex-svelte/sveltekit';
 import { api } from '$convex/_generated/api';
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals, fetch, url }) => {
   if (!locals.session) redirect(303, '/');
@@ -25,4 +25,40 @@ export const load: PageServerLoad = async ({ locals, fetch, url }) => {
     });
     redirect(303, `/app/${landing.type}`);
   }
+};
+
+export const actions: Actions = {
+  default: async ({ request, fetch, url }) => {
+    const formData = await request.formData();
+    const membershipId = formData.get('membershipId');
+
+    if (!membershipId || typeof membershipId !== 'string') {
+      return fail(400, { error: 'Please select a workspace.' });
+    }
+
+    const convex = createConvexHttpClient();
+    const membership = await convex.mutation(api.memberships.selectMembership, {
+      membershipId: membershipId,
+    });
+
+    await fetch('/api/auth/update-session', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        origin: url.origin,
+      },
+      body: JSON.stringify({
+        tenantId: membership.tenant._id,
+        tenantType: membership.tenant.type,
+        tenantName: membership.tenant.name,
+        role: membership.role,
+      }),
+    });
+
+    await fetch('/api/auth/convex/token', {
+      headers: { origin: url.origin },
+    });
+
+    redirect(303, '/');
+  },
 };

--- a/src/routes/auth/select-tenant/+page.svelte
+++ b/src/routes/auth/select-tenant/+page.svelte
@@ -1,60 +1,25 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { useMutation } from '@mmailaender/convex-svelte';
-  import { ConvexError } from 'convex/values';
-  import { setError } from 'sveltekit-superforms';
-  import { api } from '$convex/_generated/api';
-  import { authClient } from '$lib/auth-client';
+  import { page } from '$app/state';
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
-  import { createForm } from '$lib/forms';
-  import { selectMembershipSchema, type TenantType } from '$lib/schemas/auth';
+  import type { TenantType } from '$lib/schemas/auth';
   import { groupMembershipsByType } from './memberships';
 
   let { data } = $props();
 
-  // `data.memberships` and `data.user` come from `convexLoad` in
-  // `+page.ts`. Grouping lives in the colocated `./memberships`
-  // helper so it's unit-tested without a browser and Convex stays
-  // presentation-agnostic.
   const groups = $derived(groupMembershipsByType(data.memberships.data ?? []));
   const currentUser = $derived(data.user.data);
 
-  const selectMembership = useMutation(api.memberships.selectMembership);
-
-  const form = createForm({
-    schema: selectMembershipSchema,
-    onUpdate: async ({ form: submitted }) => {
-      if (!submitted.valid) return;
-
-      try {
-        const membership = await selectMembership({
-          membershipId: submitted.data.membershipId,
-        });
-        await authClient.updateSession({
-          tenantId: membership.tenant._id,
-          tenantType: membership.tenant.type,
-          tenantName: membership.tenant.name,
-          role: membership.role,
-        } as Record<string, string>);
-        const target = resolve(`/app/${membership.tenant.type}`);
-        await goto(target, { invalidateAll: true });
-      } catch (err) {
-        const message =
-          err instanceof ConvexError ? (err.data as string) : 'Could not select that workspace.';
-        setError(submitted, 'membershipId', message);
-      }
-    },
-  });
-
-  const { form: formStore, submitting, enhance } = form;
+  let selectedId = $state('');
 
   const typeLabels: Record<TenantType, string> = {
     consumer: 'Consumer',
     contractor: 'Contractor',
     admin: 'Admin',
   };
+
+  const actionError = $derived(page.form?.error as string | undefined);
 </script>
 
 <Card.Root>
@@ -75,7 +40,11 @@
         Your account isn't part of any workspace yet. Ask your administrator to add you.
       </p>
     {:else}
-      <form method="POST" use:enhance class="flex flex-col gap-5">
+      <form method="POST" class="flex flex-col gap-5">
+        {#if actionError}
+          <p class="text-sm text-destructive" role="alert">{actionError}</p>
+        {/if}
+
         {#each groups as group (group.type)}
           <fieldset class="flex flex-col gap-2">
             <legend
@@ -91,7 +60,7 @@
                   type="radio"
                   name="membershipId"
                   value={membership._id}
-                  bind:group={$formStore.membershipId}
+                  bind:group={selectedId}
                   class="size-4 text-primary focus:ring-primary"
                 />
                 <span class="flex-1">
@@ -107,9 +76,7 @@
           </fieldset>
         {/each}
 
-        <Button type="submit" disabled={$submitting || !$formStore.membershipId}>
-          {$submitting ? 'Entering…' : 'Continue'}
-        </Button>
+        <Button type="submit" disabled={!selectedId}>Continue</Button>
       </form>
     {/if}
   </Card.Content>

--- a/tests/routes/auth/select-tenant/tenant-token.spec.ts
+++ b/tests/routes/auth/select-tenant/tenant-token.spec.ts
@@ -47,6 +47,53 @@ test('selecting a tenant on the picker sets tenantId on the JWT', async ({
   expect(payload.tenantId).toBe(tenant._id);
 });
 
+test('switching tenants via header works end-to-end', async ({
+  page,
+  user,
+  tenant,
+  membership,
+}) => {
+  void membership;
+
+  const secondTenant = await createTenant({
+    name: 'Second Workspace',
+    slug: `second-${Date.now()}`,
+    type: 'contractor',
+  });
+  await createMembership({
+    userId: user.userId!,
+    tenantId: secondTenant._id!,
+    role: 'member',
+  });
+
+  await page.goto('/auth/select-tenant', { waitUntil: 'networkidle' });
+  await page.getByRole('radio', { name: tenant.name }).check();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.waitForURL(/\/app\/consumer/);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByRole('heading', { name: `Welcome to ${tenant.name}` })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Switch' }).click();
+  await expect(page).toHaveURL(/\/auth\/select-tenant/);
+
+  await page.getByRole('radio', { name: secondTenant.name }).check();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.waitForURL(/\/app\/contractor/);
+  await page.waitForLoadState('networkidle');
+  await expect(
+    page.getByRole('heading', { name: `Welcome to ${secondTenant.name}` }),
+  ).toBeVisible();
+});
+
+test('tenant-less user hitting /app/* is redirected to the picker', async ({ page }) => {
+  await page.goto('/app/consumer');
+  await expect(page).toHaveURL(/\/auth\/select-tenant/);
+  await expect(page.getByText('Choose a workspace')).toBeVisible();
+  await expect(page.getByText(/isn't part of any workspace yet/)).toBeVisible();
+});
+
 test('single-membership user is auto-redirected and JWT has tenantId', async ({
   page,
   tenant,


### PR DESCRIPTION
## Summary

Fixes #41

- **Moved tenant selection to a SvelteKit form action** — the picker now uses a plain HTML `<form method="POST">` instead of client-side `useMutation` + `authClient.updateSession` + `goto`. The server action runs the Convex mutation via `createConvexHttpClient()`, updates the Better Auth session, mints a fresh JWT cookie, and redirects via `redirect(303, '/')`. The full page load on redirect re-initializes the Convex WebSocket client with the correct tenant-scoped token, eliminating the stale-JWT race entirely.
- **Added tenantId guard in `/app` layout server load** — tenant-less users hitting `/app/*` are now redirected to `/auth/select-tenant`.

## Why a server action?

The root cause was that after `authClient.updateSession()`, the Convex WebSocket client held a stale JWT (without `tenantId`). The reactive chain that refreshes the token (`$sessionSignal` → session atom refetch → `setupAuth` `$effect` → `setAuth` → HTTP token fetch → server confirmation) takes multiple async ticks + an HTTP round-trip. No amount of `await tick()`, `flushSync`, or `queueMicrotask` could reliably guarantee the chain completed before `goto()` triggered `convexLoad()` with the stale token.

A plain form POST sidesteps this entirely: the browser does a full navigation on the 303 redirect, which re-initializes the Convex client with a fresh JWT from `hooks.ts`.

## Test plan

- [x] Login as a multi-membership user → select tenant → lands on `/app/{type}` successfully
- [x] Switch tenants via header → picker → select different tenant → lands correctly
- [x] `svelte-check`: 0 errors
- [x] `vitest run`: 37 tests pass
- [x] Pre-commit hooks pass (prettier, svelte-check, vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)