### PR TITLE
feat: move tenant context from URL to auth token

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
         "sveltekit-superforms": "^2.30.1",
         "tailwind-merge": "^3.5.0",
         "tailwind-variants": "^3.2.2",
+        "uuid": "^14.0.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -35,6 +36,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "@types/node": "^25",
+        "@types/uuid": "^11.0.0",
         "convex-test": "^0.0.50",
         "eslint": "^10.2.0",
         "eslint-config-prettier": "^10.1.8",
@@ -370,6 +372,8 @@
     "@types/ssh2-streams": ["@types/ssh2-streams@0.1.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/uuid": ["@types/uuid@11.0.0", "", { "dependencies": { "uuid": "*" } }, "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA=="],
 
     "@types/validator": ["@types/validator@13.15.10", "", {}, "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA=="],
 
@@ -1025,7 +1029,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "valibot": ["valibot@1.3.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-sfdRir/QFM0JaF22hqTroPc5xy4DimuGQVKFrzF1YfGwaS1nJot3Y8VqMdLO2Lg27fMzat2yD3pY5PbAYO39Gg=="],
 
@@ -1118,6 +1122,8 @@
     "docker-modem/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "dockerode/tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
+
+    "dockerode/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "eslint-plugin-svelte/globals": ["globals@16.5.0", "", {}, "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^25",
+    "@types/uuid": "^11.0.0",
     "convex-test": "^0.0.50",
     "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
@@ -70,6 +71,7 @@
     "sveltekit-superforms": "^2.30.1",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
+    "uuid": "^14.0.0",
     "zod": "^4.3.6"
   }
 }

--- a/src/convex/admin.ts
+++ b/src/convex/admin.ts
@@ -1,6 +1,7 @@
 import { ConvexError } from 'convex/values';
 import { z } from 'zod';
 import { zid } from 'convex-helpers/server/zod4';
+import { v7 as uuidv7 } from 'uuid';
 import { authComponent, createAuth } from './auth';
 import { isMembershipActive } from './memberships';
 import { adminAction, adminMutation, adminQuery } from './functions';
@@ -20,7 +21,7 @@ export const listTenants = adminQuery({
         return {
           _id: tenant._id,
           name: tenant.name,
-          slug: tenant.slug,
+          uuid: tenant.uuid,
           type: tenant.type,
           memberCount: memberships.filter(isMembershipActive).length,
           totalMemberCount: memberships.length,
@@ -59,7 +60,7 @@ export const getTenantWithMemberships = adminQuery({
     return {
       _id: tenant._id,
       name: tenant.name,
-      slug: tenant.slug,
+      uuid: tenant.uuid,
       type: tenant.type,
       _creationTime: tenant._creationTime,
       memberships: hydrated,
@@ -175,20 +176,10 @@ export const listAllUsers = adminQuery({
 export const createTenant = adminMutation({
   args: {
     name: z.string().min(1),
-    slug: z
-      .string()
-      .min(1)
-      .regex(/^[a-z0-9-]+$/),
     type: z.enum(['consumer', 'contractor']),
   },
-  handler: async (ctx, { name, slug, type }) => {
-    const existing = await ctx.db
-      .query('tenants')
-      .withIndex('by_slug', (q) => q.eq('slug', slug))
-      .unique();
-    if (existing) throw new ConvexError('A tenant with that slug already exists');
-
-    return ctx.db.insert('tenants', { name, slug, type });
+  handler: async (ctx, { name, type }) => {
+    return ctx.db.insert('tenants', { name, uuid: uuidv7(), type });
   },
 });
 

--- a/src/convex/auth.ts
+++ b/src/convex/auth.ts
@@ -96,13 +96,8 @@ export const getCurrentUser = query({
  *   - `null` — zero active memberships (send the user to
  *     `/auth/select-tenant`, which will show the "contact your admin"
  *     copy) OR two+ active memberships (force an explicit pick).
- *   - `{ type, slug }` — the user's single active membership. Auto-land.
- *
- * Archived memberships don't count. `selectedAt` is always set (schema
- * guarantee), so the "has the user ever picked one?" heuristic that used
- * to live here isn't meaningful anymore — the picker itself orders by
- * `selectedAt` descending so a returning user with 2+ workspaces sees
- * their last choice at the top.
+ *   - `{ type, name, tenantId, role }` — the user's single active
+ *     membership. Auto-land.
  *
  * Returns `null` entirely when the caller isn't authenticated.
  */
@@ -125,7 +120,6 @@ export const getDefaultLanding = query({
 
     return {
       type: tenant.type,
-      slug: tenant.slug,
       name: tenant.name,
       tenantId: tenant._id,
       role: active.role,

--- a/src/convex/betterAuth/_generated/component.ts
+++ b/src/convex/betterAuth/_generated/component.ts
@@ -117,7 +117,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -156,7 +155,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -196,7 +194,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -229,7 +226,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -261,7 +257,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -314,7 +309,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -353,7 +347,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -393,7 +386,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -426,7 +418,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -458,7 +449,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -506,7 +496,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           where?: Array<{
             connector?: "AND" | "OR";
             field: string;
-            mode?: "sensitive" | "insensitive";
             operator?:
               | "lt"
               | "lte"
@@ -541,7 +530,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           where?: Array<{
             connector?: "AND" | "OR";
             field: string;
-            mode?: "sensitive" | "insensitive";
             operator?:
               | "lt"
               | "lte"
@@ -593,7 +581,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -645,7 +632,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -699,7 +685,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -739,7 +724,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -777,7 +761,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -839,7 +822,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "updatedAt"
                     | "userId"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -891,7 +873,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "tenantName"
                     | "role"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -945,7 +926,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -985,7 +965,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "updatedAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"
@@ -1023,7 +1002,6 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
                     | "createdAt"
                     | "expiresAt"
                     | "_id";
-                  mode?: "sensitive" | "insensitive";
                   operator?:
                     | "lt"
                     | "lte"

--- a/src/convex/init.ts
+++ b/src/convex/init.ts
@@ -1,4 +1,5 @@
 import { ConvexError, v } from 'convex/values';
+import { v7 as uuidv7 } from 'uuid';
 import { internalAction, internalMutation } from './_generated/server';
 import { internal } from './_generated/api';
 import type { Doc, Id } from './_generated/dataModel';
@@ -8,8 +9,8 @@ type TenantType = Doc<'tenants'>['type'];
 type MembershipRole = Doc<'memberships'>['role'];
 
 type SeedUser = { email: string; name: string; password: string };
-type SeedTenant = { slug: string; name: string; type: TenantType };
-type SeedMembership = { email: string; tenantSlug: string; role: MembershipRole };
+type SeedTenant = { name: string; type: TenantType };
+type SeedMembership = { email: string; tenantName: string; role: MembershipRole };
 
 /**
  * Local dev fixtures. This file IS the "what exists in my dev DB"
@@ -18,7 +19,7 @@ type SeedMembership = { email: string; tenantSlug: string; role: MembershipRole 
  * The declaration order (users → tenants → memberships) mirrors the
  * dependency order: a membership needs both a user and a tenant to exist
  * before it can point at them, and we don't have real ids yet when we're
- * authoring this, so memberships are keyed by `email` and `tenantSlug`.
+ * authoring this, so memberships are keyed by `email` and `tenantName`.
  * Those resolve to real ids at apply time.
  *
  * To wipe the deployment run `bun run clear`. To wipe and reseed,
@@ -40,24 +41,24 @@ export const SEED_USERS: ReadonlyArray<SeedUser> = [
 ];
 
 const SEED_TENANTS: ReadonlyArray<SeedTenant> = [
-  { slug: 'acme-test', name: 'Acme Test', type: 'consumer' },
-  { slug: 'fixit-test', name: 'FixIt Test', type: 'contractor' },
-  { slug: 'fleet-ops', name: 'Fleet Ops', type: 'admin' },
+  { name: 'Acme Test', type: 'consumer' },
+  { name: 'FixIt Test', type: 'contractor' },
+  { name: 'Fleet Ops', type: 'admin' },
 ];
 
 export const SEED_MEMBERSHIPS: ReadonlyArray<SeedMembership> = [
   // Real users — full access
-  { email: 'elitonmachadod200@gmail.com', tenantSlug: 'acme-test', role: 'owner' },
-  { email: 'elitonmachadod200@gmail.com', tenantSlug: 'fixit-test', role: 'owner' },
-  { email: 'elitonmachadod200@gmail.com', tenantSlug: 'fleet-ops', role: 'owner' },
+  { email: 'elitonmachadod200@gmail.com', tenantName: 'Acme Test', role: 'owner' },
+  { email: 'elitonmachadod200@gmail.com', tenantName: 'FixIt Test', role: 'owner' },
+  { email: 'elitonmachadod200@gmail.com', tenantName: 'Fleet Ops', role: 'owner' },
 
   // Fake users — varied membership scenarios
-  { email: 'alice@example.com', tenantSlug: 'acme-test', role: 'admin' },
-  { email: 'alice@example.com', tenantSlug: 'fixit-test', role: 'member' },
-  { email: 'bob@example.com', tenantSlug: 'acme-test', role: 'member' },
-  { email: 'john@example.com', tenantSlug: 'fixit-test', role: 'admin' },
-  { email: 'jane@example.com', tenantSlug: 'acme-test', role: 'member' },
-  { email: 'jane@example.com', tenantSlug: 'fixit-test', role: 'member' },
+  { email: 'alice@example.com', tenantName: 'Acme Test', role: 'admin' },
+  { email: 'alice@example.com', tenantName: 'FixIt Test', role: 'member' },
+  { email: 'bob@example.com', tenantName: 'Acme Test', role: 'member' },
+  { email: 'john@example.com', tenantName: 'FixIt Test', role: 'admin' },
+  { email: 'jane@example.com', tenantName: 'Acme Test', role: 'member' },
+  { email: 'jane@example.com', tenantName: 'FixIt Test', role: 'member' },
   // charlie and diana have no memberships — orphaned users for testing
 ];
 
@@ -119,25 +120,21 @@ export default internalAction({
 export const applyFixtures = internalMutation({
   args: { userIdByEmail: v.record(v.string(), v.string()) },
   handler: async (ctx, { userIdByEmail }): Promise<void> => {
-    const tenantIdBySlug: Record<string, Id<'tenants'>> = {};
+    const tenantIdByName: Record<string, Id<'tenants'>> = {};
     for (const t of SEED_TENANTS) {
-      tenantIdBySlug[t.slug] = await ctx.db.insert('tenants', {
-        slug: t.slug,
+      tenantIdByName[t.name] = await ctx.db.insert('tenants', {
         name: t.name,
+        uuid: uuidv7(),
         type: t.type,
       });
     }
 
-    // All memberships in a single seed run get the same stamp; the
-    // schema just wants a non-null number and the tenant-picker's sort
-    // order doesn't matter for seed data that'll be rewritten the first
-    // time the user actually picks a tenant.
     const now = Date.now();
     for (const m of SEED_MEMBERSHIPS) {
       const userId = userIdByEmail[m.email];
-      const tenantId = tenantIdBySlug[m.tenantSlug];
+      const tenantId = tenantIdByName[m.tenantName];
       if (!userId) throw new ConvexError(`seed: no user ${m.email}`);
-      if (!tenantId) throw new ConvexError(`seed: no tenant ${m.tenantSlug}`);
+      if (!tenantId) throw new ConvexError(`seed: no tenant ${m.tenantName}`);
 
       await ctx.db.insert('memberships', {
         userId,

--- a/src/convex/memberships.ts
+++ b/src/convex/memberships.ts
@@ -97,7 +97,6 @@ export const listMyMemberships = zQuery({
           tenant: {
             _id: tenant._id,
             name: tenant.name,
-            slug: tenant.slug,
             type: tenant.type,
           },
         };
@@ -109,17 +108,10 @@ export const listMyMemberships = zQuery({
 });
 
 /**
- * Stamps `selectedAt = now` on the caller's membership. The URL chosen
- * next is the only place an "active membership" decision is actually
- * recorded, and the stamp is what makes that row sort first on the
- * tenant-picker next time around.
+ * Stamps `selectedAt = now` on the caller's membership.
  *
  * Returns the updated membership with its tenant hydrated so the caller
- * can navigate straight to `/app/[type]/[slug]` without a follow-up query.
- *
- * Throws if the membership doesn't exist, doesn't belong to the caller
- * (prevents stamping someone else's row), or is archived (an archived
- * membership isn't a valid destination — restore it first).
+ * can navigate to the correct app surface without a follow-up query.
  */
 export const selectMembership = zMutation({
   args: { membershipId: zid('memberships') },
@@ -143,7 +135,6 @@ export const selectMembership = zMutation({
       tenant: {
         _id: tenant._id,
         name: tenant.name,
-        slug: tenant.slug,
         type: tenant.type,
       },
     };

--- a/src/convex/schema.ts
+++ b/src/convex/schema.ts
@@ -4,14 +4,9 @@ import { v } from 'convex/values';
 export default defineSchema({
   tenants: defineTable({
     name: v.string(),
-    // URL-safe, globally unique across all tenant types. Acts as the
-    // tab-level identity under /app/[type]/[slug]/*.
-    slug: v.string(),
-    // Each tenant type is a distinct product surface with its own routes,
-    // navigation, and Convex modules. Adding a new type means a new URL
-    // prefix + a new folder tree — never a conditional.
+    uuid: v.string(),
     type: v.union(v.literal('consumer'), v.literal('contractor'), v.literal('admin')),
-  }).index('by_slug', ['slug']),
+  }).index('by_uuid', ['uuid']),
 
   memberships: defineTable({
     userId: v.string(),

--- a/src/convex/tenant_test_helper.ts
+++ b/src/convex/tenant_test_helper.ts
@@ -1,16 +1,16 @@
 import { ConvexError, v } from 'convex/values';
+import { v7 as uuidv7 } from 'uuid';
 import { mutation } from './_generated/server';
 
 export const createTenant = mutation({
   args: {
     name: v.string(),
-    slug: v.string(),
     type: v.union(v.literal('consumer'), v.literal('contractor'), v.literal('admin')),
   },
   handler: async (ctx, args) => {
     if (process.env.IS_TEST !== 'true') {
       throw new ConvexError('Test-only mutation');
     }
-    return await ctx.db.insert('tenants', args);
+    return await ctx.db.insert('tenants', { ...args, uuid: uuidv7() });
   },
 });

--- a/src/routes/app/+layout.server.ts
+++ b/src/routes/app/+layout.server.ts
@@ -13,4 +13,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
     const next = encodeURIComponent(url.pathname + url.search);
     redirect(303, `/auth/login?next=${next}`);
   }
+
+  if (!locals.session.tenantId) {
+    redirect(303, '/auth/select-tenant');
+  }
 };

--- a/src/routes/app/admin/+page.svelte
+++ b/src/routes/app/admin/+page.svelte
@@ -52,7 +52,7 @@
         {#each tenants as tenant (tenant._id)}
           <TenantRow
             name={tenant.name}
-            detail="/{tenant.slug} &middot; {tenant.type.toUpperCase()} &middot; {tenant.memberCount} active member{tenant.memberCount ===
+            detail="{tenant.type.toUpperCase()} &middot; {tenant.memberCount} active member{tenant.memberCount ===
             1
               ? ''
               : 's'}"

--- a/src/routes/app/admin/components/tenant-dashboard/tenant-dashboard.svelte
+++ b/src/routes/app/admin/components/tenant-dashboard/tenant-dashboard.svelte
@@ -3,13 +3,13 @@
 
   interface Props {
     name: string;
-    slug: string;
+    uuid: string;
     type: string;
     createdAt: number;
     memberCounts: { owners: number; admins: number; members: number; archived: number };
   }
 
-  let { name, slug, type, createdAt, memberCounts }: Props = $props();
+  let { name, uuid, type, createdAt, memberCounts }: Props = $props();
 </script>
 
 <div class="grid gap-4 sm:grid-cols-2">
@@ -24,8 +24,8 @@
           <dd class="font-medium text-foreground">{name}</dd>
         </div>
         <div class="flex justify-between">
-          <dt class="text-muted-foreground">Slug</dt>
-          <dd class="font-mono text-foreground">/{slug}</dd>
+          <dt class="text-muted-foreground">UUID</dt>
+          <dd class="font-mono text-xs text-foreground">{uuid}</dd>
         </div>
         <div class="flex justify-between">
           <dt class="text-muted-foreground">Type</dt>

--- a/src/routes/app/admin/tenants/+page.svelte
+++ b/src/routes/app/admin/tenants/+page.svelte
@@ -19,29 +19,18 @@
 
   let addOpen = $state(false);
   let newName = $state('');
-  let newSlug = $state('');
   let newType = $state<'consumer' | 'contractor'>('consumer');
   let actionError = $state('');
 
-  const derivedSlug = $derived(
-    newSlug ||
-      newName
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, ''),
-  );
-
   async function handleCreate() {
-    if (!newName.trim() || !derivedSlug) return;
+    if (!newName.trim()) return;
     try {
       actionError = '';
       await createTenant({
         name: newName.trim(),
-        slug: derivedSlug,
         type: newType,
       });
       newName = '';
-      newSlug = '';
       newType = 'consumer';
       addOpen = false;
     } catch (e: unknown) {
@@ -70,7 +59,7 @@
     {#each tenants as tenant (tenant._id)}
       <TenantRow
         name={tenant.name}
-        detail="/{tenant.slug} &middot; {tenant.type.toUpperCase()} &middot; {tenant.memberCount} active / {tenant.totalMemberCount} total"
+        detail="{tenant.type.toUpperCase()} &middot; {tenant.memberCount} active / {tenant.totalMemberCount} total"
         href={resolve(`/app/admin/tenants/${tenant._id}`)}
       />
     {:else}
@@ -104,20 +93,6 @@
             <div>
               <Label for="tenant-name">Name</Label>
               <Input id="tenant-name" type="text" bind:value={newName} placeholder="Acme Corp" />
-            </div>
-            <div>
-              <Label for="tenant-slug">Slug</Label>
-              <Input
-                id="tenant-slug"
-                type="text"
-                bind:value={newSlug}
-                placeholder={derivedSlug || 'auto-generated-from-name'}
-              />
-              {#if derivedSlug}
-                <p class="mt-1 text-xs text-muted-foreground">
-                  Will be accessible at <span class="font-mono">/{derivedSlug}</span>
-                </p>
-              {/if}
             </div>
             <div>
               <Label for="tenant-type">Type</Label>

--- a/src/routes/app/admin/tenants/[tenantId]/+page.svelte
+++ b/src/routes/app/admin/tenants/[tenantId]/+page.svelte
@@ -39,7 +39,8 @@
       <div>
         <h1 class="text-2xl font-semibold tracking-tight text-foreground">{tenant.name}</h1>
         <p class="mt-1 text-sm text-muted-foreground">
-          /{tenant.slug} &middot; <span class="uppercase">{tenant.type}</span>
+          <span class="font-mono text-xs">{tenant.uuid}</span> &middot;
+          <span class="uppercase">{tenant.type}</span>
         </p>
       </div>
       <Button href={resolve('/app/admin/tenants')} variant="outline" size="sm">
@@ -56,7 +57,7 @@
       <Tabs.Content value="dashboard" class="pt-4">
         <TenantDashboard
           name={tenant.name}
-          slug={tenant.slug}
+          uuid={tenant.uuid}
           type={tenant.type}
           createdAt={tenant._creationTime}
           memberCounts={memberCounts()}

--- a/src/routes/auth/select-tenant/+page.server.ts
+++ b/src/routes/auth/select-tenant/+page.server.ts
@@ -1,7 +1,7 @@
-import { redirect } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import { createConvexHttpClient } from '@mmailaender/convex-svelte/sveltekit';
 import { api } from '$convex/_generated/api';
-import type { PageServerLoad } from './$types';
+import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals, fetch, url }) => {
   if (!locals.session) redirect(303, '/');
@@ -25,4 +25,40 @@ export const load: PageServerLoad = async ({ locals, fetch, url }) => {
     });
     redirect(303, `/app/${landing.type}`);
   }
+};
+
+export const actions: Actions = {
+  default: async ({ request, fetch, url }) => {
+    const formData = await request.formData();
+    const membershipId = formData.get('membershipId');
+
+    if (!membershipId || typeof membershipId !== 'string') {
+      return fail(400, { error: 'Please select a workspace.' });
+    }
+
+    const convex = createConvexHttpClient();
+    const membership = await convex.mutation(api.memberships.selectMembership, {
+      membershipId: membershipId,
+    });
+
+    await fetch('/api/auth/update-session', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        origin: url.origin,
+      },
+      body: JSON.stringify({
+        tenantId: membership.tenant._id,
+        tenantType: membership.tenant.type,
+        tenantName: membership.tenant.name,
+        role: membership.role,
+      }),
+    });
+
+    await fetch('/api/auth/convex/token', {
+      headers: { origin: url.origin },
+    });
+
+    redirect(303, '/');
+  },
 };

--- a/src/routes/auth/select-tenant/+page.svelte
+++ b/src/routes/auth/select-tenant/+page.svelte
@@ -1,60 +1,25 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { useMutation } from '@mmailaender/convex-svelte';
-  import { ConvexError } from 'convex/values';
-  import { setError } from 'sveltekit-superforms';
-  import { api } from '$convex/_generated/api';
-  import { authClient } from '$lib/auth-client';
+  import { page } from '$app/state';
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
-  import { createForm } from '$lib/forms';
-  import { selectMembershipSchema, type TenantType } from '$lib/schemas/auth';
+  import type { TenantType } from '$lib/schemas/auth';
   import { groupMembershipsByType } from './memberships';
 
   let { data } = $props();
 
-  // `data.memberships` and `data.user` come from `convexLoad` in
-  // `+page.ts`. Grouping lives in the colocated `./memberships`
-  // helper so it's unit-tested without a browser and Convex stays
-  // presentation-agnostic.
   const groups = $derived(groupMembershipsByType(data.memberships.data ?? []));
   const currentUser = $derived(data.user.data);
 
-  const selectMembership = useMutation(api.memberships.selectMembership);
-
-  const form = createForm({
-    schema: selectMembershipSchema,
-    onUpdate: async ({ form: submitted }) => {
-      if (!submitted.valid) return;
-
-      try {
-        const membership = await selectMembership({
-          membershipId: submitted.data.membershipId,
-        });
-        await authClient.updateSession({
-          tenantId: membership.tenant._id,
-          tenantType: membership.tenant.type,
-          tenantName: membership.tenant.name,
-          role: membership.role,
-        } as Record<string, string>);
-        const target = resolve(`/app/${membership.tenant.type}`);
-        await goto(target, { invalidateAll: true });
-      } catch (err) {
-        const message =
-          err instanceof ConvexError ? (err.data as string) : 'Could not select that workspace.';
-        setError(submitted, 'membershipId', message);
-      }
-    },
-  });
-
-  const { form: formStore, submitting, enhance } = form;
+  let selectedId = $state('');
 
   const typeLabels: Record<TenantType, string> = {
     consumer: 'Consumer',
     contractor: 'Contractor',
     admin: 'Admin',
   };
+
+  const actionError = $derived(page.form?.error as string | undefined);
 </script>
 
 <Card.Root>
@@ -75,7 +40,11 @@
         Your account isn't part of any workspace yet. Ask your administrator to add you.
       </p>
     {:else}
-      <form method="POST" use:enhance class="flex flex-col gap-5">
+      <form method="POST" class="flex flex-col gap-5">
+        {#if actionError}
+          <p class="text-sm text-destructive" role="alert">{actionError}</p>
+        {/if}
+
         {#each groups as group (group.type)}
           <fieldset class="flex flex-col gap-2">
             <legend
@@ -91,7 +60,7 @@
                   type="radio"
                   name="membershipId"
                   value={membership._id}
-                  bind:group={$formStore.membershipId}
+                  bind:group={selectedId}
                   class="size-4 text-primary focus:ring-primary"
                 />
                 <span class="flex-1">
@@ -107,9 +76,7 @@
           </fieldset>
         {/each}
 
-        <Button type="submit" disabled={$submitting || !$formStore.membershipId}>
-          {$submitting ? 'Entering…' : 'Continue'}
-        </Button>
+        <Button type="submit" disabled={!selectedId}>Continue</Button>
       </form>
     {/if}
   </Card.Content>

--- a/tests/routes/auth/select-tenant/tenant-token.spec.ts
+++ b/tests/routes/auth/select-tenant/tenant-token.spec.ts
@@ -21,7 +21,6 @@ test('selecting a tenant on the picker sets tenantId on the JWT', async ({
 
   const secondTenant = await createTenant({
     name: 'Second Workspace',
-    slug: `second-${Date.now()}`,
     type: 'contractor',
   });
   await createMembership({
@@ -57,7 +56,6 @@ test('switching tenants via header works end-to-end', async ({
 
   const secondTenant = await createTenant({
     name: 'Second Workspace',
-    slug: `second-${Date.now()}`,
     type: 'contractor',
   });
   await createMembership({

--- a/tests/routes/auth/select-tenant/tenant-token.spec.ts
+++ b/tests/routes/auth/select-tenant/tenant-token.spec.ts
@@ -47,6 +47,53 @@ test('selecting a tenant on the picker sets tenantId on the JWT', async ({
   expect(payload.tenantId).toBe(tenant._id);
 });
 
+test('switching tenants via header works end-to-end', async ({
+  page,
+  user,
+  tenant,
+  membership,
+}) => {
+  void membership;
+
+  const secondTenant = await createTenant({
+    name: 'Second Workspace',
+    slug: `second-${Date.now()}`,
+    type: 'contractor',
+  });
+  await createMembership({
+    userId: user.userId!,
+    tenantId: secondTenant._id!,
+    role: 'member',
+  });
+
+  await page.goto('/auth/select-tenant', { waitUntil: 'networkidle' });
+  await page.getByRole('radio', { name: tenant.name }).check();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.waitForURL(/\/app\/consumer/);
+  await page.waitForLoadState('networkidle');
+  await expect(page.getByRole('heading', { name: `Welcome to ${tenant.name}` })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Switch' }).click();
+  await expect(page).toHaveURL(/\/auth\/select-tenant/);
+
+  await page.getByRole('radio', { name: secondTenant.name }).check();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.waitForURL(/\/app\/contractor/);
+  await page.waitForLoadState('networkidle');
+  await expect(
+    page.getByRole('heading', { name: `Welcome to ${secondTenant.name}` }),
+  ).toBeVisible();
+});
+
+test('tenant-less user hitting /app/* is redirected to the picker', async ({ page }) => {
+  await page.goto('/app/consumer');
+  await expect(page).toHaveURL(/\/auth\/select-tenant/);
+  await expect(page.getByText('Choose a workspace')).toBeVisible();
+  await expect(page.getByText(/isn't part of any workspace yet/)).toBeVisible();
+});
+
 test('single-membership user is auto-redirected and JWT has tenantId', async ({
   page,
   tenant,

--- a/tests/support/convex.ts
+++ b/tests/support/convex.ts
@@ -50,7 +50,7 @@ export async function createUser(user: TestUser): Promise<TestUser> {
 type TenantType = Doc<'tenants'>['type'];
 type MembershipRole = Doc<'memberships'>['role'];
 
-export type TestTenant = { name: string; slug: string; type: TenantType; _id?: Id<'tenants'> };
+export type TestTenant = { name: string; type: TenantType; _id?: Id<'tenants'> };
 
 let _convexClient: ConvexHttpClient | undefined;
 const convexClient = () =>
@@ -58,7 +58,6 @@ const convexClient = () =>
 
 export async function createTenant(tenant: {
   name: string;
-  slug: string;
   type: TenantType;
 }): Promise<TestTenant> {
   const client = convexClient();

--- a/tests/support/fixtures.ts
+++ b/tests/support/fixtures.ts
@@ -59,7 +59,6 @@ export const test = base.extend<Fixtures>({
     const id = randomBytes(6).toString('hex');
     const tenant = await createTenant({
       name: `Tenant ${id}`,
-      slug: `tenant-${id}`,
       type: 'consumer',
     });
     await use(tenant);


### PR DESCRIPTION
## Summary

- Migrates tenant identity from URL slug (`/app/[type]/[tenantSlug]/*`) to JWT-based auth token, completing the full token-based tenant auth architecture
- Adds `azQuery`/`azMutation` function builders that read tenant from auth context, eliminating slug threading through every Convex function
- Replaces the `slug` schema field with auto-generated UUIDv7, removing all slug terminology from the codebase
- Simplifies admin tenant creation (name + type only, UUID auto-generated)

Closes #3, closes #14

## Test plan

- [x] All 37 unit tests pass (Vitest)
- [x] Type checking clean (`svelte-check`)
- [x] Lint clean (Prettier + ESLint)
- [ ] E2E tests: single-tenant auto-redirect, multi-tenant picker, tenant switch, tenantless redirect
- [ ] Manual smoke test: admin, consumer, contractor surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)