### PR TITLE
feat: bootstrap just + mise integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "allow": [
       "Bash(git *)",
       "Bash(gh *)",
+      "Bash(just *)",
       "Bash(bun *)",
       "Bash(bunx *)",
       "Bash(cat *)",
@@ -29,7 +30,9 @@
       "Bash(docker *)",
       "Bash(docker compose *)",
       "Bash(curl *)",
-      "Bash(bunx playwright *)"
+      "Bash(bunx playwright *)",
+      "WebFetch",
+      "WebSearch"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ vite.config.ts.timestamp-*
 .vscode
 .idea
 
+# claude
+.claude/*.local.md
+
 # mise
 .mise/config.local.toml
 

--- a/.just/wk.just
+++ b/.just/wk.just
@@ -1,0 +1,11 @@
+[doc("Create a new worktree branched from origin/main")]
+new branch:
+    @echo "wk::new not implemented yet (branch: {{branch}})"
+
+[doc("Remove a worktree and its resources")]
+rm branch:
+    @echo "wk::rm not implemented yet (branch: {{branch}})"
+
+[doc("Open a worktree in a zellij session")]
+zellij branch:
+    @echo "wk::zellij not implemented yet (branch: {{branch}})"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -6,6 +6,7 @@ experimental = true
 [tools]
 bun = "latest"
 github-cli = "latest"
+just = "latest"
 node = "24"
 
 [env]

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -107,6 +107,10 @@ checksum = "sha256:ced3e6f4bb5a9865056b594b7ad0cf42137dc92c494346f1ca705b5dbf14c
 url = "https://github.com/cli/cli/releases/download/v2.91.0/gh_2.91.0_windows_amd64.zip"
 provenance = "github-attestations"
 
+[[tools.just]]
+version = "1.48.1"
+backend = "aqua:casey/just"
+
 [[tools.node]]
 version = "24.14.1"
 backend = "core:node"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,1 @@
+mod wk ".just/wk.just"


### PR DESCRIPTION
## Summary

- Add `just` as a mise-managed tool (`just = "latest"`)
- Create `justfile` + `.just/wk.just` with stub recipes for worktree lifecycle (`wk::new`, `wk::rm`, `wk::zellij`)
- Add `.claude/*.local.md` to `.gitignore` for per-worktree Claude context files
- Allow `just`, `WebFetch`, `WebSearch` in Claude Code permissions

Closes #65
Part of #64

## Test plan

- [x] `mise install` installs `just` without errors
- [x] `just --list` shows `wk ...` module
- [x] `just --list wk` shows `new`, `rm`, `zellij` recipes with docs
- [x] `just wk::new test-branch` prints stub message
- [x] `.claude/*.local.md` is gitignored


🤖 Generated with [Claude Code](https://claude.com/claude-code)