### PR TITLE
feat: zellij layout + wk::zellij recipe

### DIFF
--- a/.just/wk.just
+++ b/.just/wk.just
@@ -32,10 +32,30 @@ new branch:
 
     echo "==> Worktree '{{branch}}' is ready at ../{{branch}}"
 
+[doc("Create a new worktree and open it in a zellij tab")]
+new_ui branch: (new branch) (zellij branch)
+
 [doc("Remove a worktree and its resources")]
 rm branch:
     @echo "wk::rm not implemented yet (branch: {{branch}})"
 
-[doc("Open a worktree in a zellij session")]
+[doc("Open a worktree in a zellij tab")]
 zellij branch:
-    @echo "wk::zellij not implemented yet (branch: {{branch}})"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    worktree_path="{{parent_dir}}/{{branch}}"
+
+    if [ -z "${ZELLIJ_SESSION_NAME:-}" ]; then
+        echo "Error: not inside a zellij session. Start zellij first."
+        exit 1
+    fi
+
+    if [ ! -d "${worktree_path}" ]; then
+        echo "Error: worktree '../{{branch}}' does not exist. Run 'just wk::new {{branch}}' first."
+        exit 1
+    fi
+
+    zellij action new-tab \
+        --layout "{{repo_root}}/.zellij/layout.kdl" \
+        --cwd "${worktree_path}" \
+        --name "{{branch}}"

--- a/.zellij/layout.kdl
+++ b/.zellij/layout.kdl
@@ -1,0 +1,26 @@
+layout {
+    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="tab-bar"
+        }
+        children
+        pane size=1 borderless=true {
+            plugin location="status-bar"
+        }
+    }
+
+    tab split_direction="vertical" {
+        pane size="50%"
+        pane size="50%" stacked=true {
+            pane command="$SHELL" {
+                args "-lic" "docker compose up"
+            }
+            pane command="$SHELL" {
+                args "-lic" "bun dev"
+            }
+            pane focus=true command="$SHELL" {
+                args "-lic" "claude"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `.zellij/layout.kdl` with 50/50 split: shell left, stacked services (docker compose, bun dev, claude) right
- Add `just wk::zellij <branch>` recipe to open a worktree as a zellij tab with the predefined layout
- Add `just wk::new_ui <branch>` recipe that combines worktree creation + zellij tab setup

Closes #68

## Test plan
- [x] `just wk::new_ui my-feature` creates worktree and opens zellij tab
- [x] `just wk::zellij my-feature` opens existing worktree in a new zellij tab
- [x] Layout shows 50/50 split with stacked panes on the right
- [x] Claude pane is focused by default in the stack
- [x] Tab is named after the branch
- [x] Errors if not inside a zellij session
- [x] Errors if worktree doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)