### PR TITLE
fix: add shell and agent rules, improve worktree template

### DIFF
--- a/.just/templates/worktree.template.md
+++ b/.just/templates/worktree.template.md
@@ -1,4 +1,3 @@
 ## Worktree
 
-Branch: ${BRANCH} (based on origin/main)
-Port offset: ${OFFSET}
+You are working in an isolated git worktree with its own dependencies and dedicated dev servers on non-standard ports (offset: ${OFFSET}). This directory is the git root — not `../fleet`. Branch: `${BRANCH}`(based on`origin/main`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,3 +17,14 @@ Before starting work, read any docs that match the task at hand:
 - Before creating or modifying skills, docs: read `docs/skills-and-docs.md`
 - Before starting a containerized development environment: read `docs/docker-setup.md`
 - Before creating or modifying CI/CD workflows: read `docs/cicd.md`
+
+## Shell Rules
+
+- **Never use `find -exec`**. It triggers a permission prompt that cannot be auto-allowed. Use one of these alternatives:
+  - `find ... -print0 | xargs -0 command` (pipe to xargs)
+  - `fd` (already in the allowed list, modern alternative to find)
+- **Never use `npm` or `npx`**. Always use `bun` and `bunx` instead.
+
+## Agent Rules
+
+- **Never use the `AskUserQuestion` tool.** If you need clarification, state your assumption and proceed. If you need to present options, list them in plain text output instead.


### PR DESCRIPTION
## Summary
- Ban `find -exec` in CLAUDE.md (use `xargs`/`fd` instead) to avoid unbypassable permission prompts
- Enforce `bun`/`bunx` over `npm`/`npx` in CLAUDE.md
- Disable `AskUserQuestion` tool for agents
- Rewrite worktree template to clarify that the worktree is an isolated git root with dedicated servers

## Test plan
- [ ] Verify `find -exec` is no longer used by Claude agents in new sessions
- [ ] Verify `npm`/`npx` is not used by agents
- [ ] Create a new worktree with `just wk::new` and confirm the generated `.claude/worktree.local.md` reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)