### PR TITLE
fix: treat empty-string secrets as missing in generate-convex-secrets

### DIFF
--- a/scripts/generate-convex-secrets.ts
+++ b/scripts/generate-convex-secrets.ts
@@ -75,8 +75,8 @@ async function main() {
   const existing = read(ENV_PATH);
 
   const instanceName = existing.INSTANCE_NAME ?? 'convex-self-hosted';
-  const instanceSecret = existing.INSTANCE_SECRET ?? randomHex();
-  const betterAuthSecret = existing.BETTER_AUTH_SECRET ?? randomHex();
+  const instanceSecret = existing.INSTANCE_SECRET || randomHex();
+  const betterAuthSecret = existing.BETTER_AUTH_SECRET || randomHex();
   const adminKey = await generateAdminKey(instanceName, instanceSecret);
 
   const entries: Record<string, string> = {


### PR DESCRIPTION
## Summary
- `generate-convex-secrets.ts` used `??` (nullish coalescing) to fall back to `randomHex()` when secrets were missing from `.env`
- Empty-string values like `INSTANCE_SECRET=` are **not** nullish, so `??` kept the empty string instead of generating a new secret
- This caused `generate_key` to fail with a missing `<INSTANCE_SECRET>` argument
- Switched to `||` so empty strings also trigger regeneration

## Test plan
- [x] Pre-commit hooks pass (prettier, svelte-check, vitest — 46 tests)
- [x] Run `bun scripts/generate-convex-secrets.ts` with empty secret values in `.env` and confirm secrets are generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)