### PR TITLE
fix: always force worktree removal to prevent leftover directories

### DIFF
--- a/.just/wk.just
+++ b/.just/wk.just
@@ -63,11 +63,7 @@ rm branch=`git branch --show-current` force="":
     fi
 
     echo "==> Removing git worktree"
-    if [ "${force}" = "force" ]; then
-        git worktree remove "${worktree_path}" --force
-    else
-        git worktree remove "${worktree_path}"
-    fi
+    git worktree remove "${worktree_path}" --force
 
     echo "==> Deleting branch '{{branch}}'"
     if [ "${force}" = "force" ]; then


### PR DESCRIPTION
## Summary
- Always use `--force` with `git worktree remove` in `wk::rm` to prevent leftover directories
- `wk::new` creates gitignored files (`.env`, `.claude/*.local.md`) and dev servers generate `.vite/`, which cause `git worktree remove` (without `--force`) to fail — leaving orphaned directories behind

Closes #84

## Test plan
- [ ] Run `just wk::new test-branch`, start dev server briefly, then `just wk::rm test-branch` — verify no leftover directory remains
- [ ] Run `just wk::rm` on a clean worktree — verify it still works as before
- [ ] Verify `just wk::rm main` is still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)