### PR TITLE
fix: handle orphaned worktree directories and silent grep failure in wk::rm

### DIFF
--- a/.just/wk.just
+++ b/.just/wk.just
@@ -48,9 +48,10 @@ rm branch=`git branch --show-current` force="":
         exit 1
     fi
 
-    worktree_path=$(git worktree list | grep "\[{{branch}}\]" | awk '{print $1}')
+    worktree_path="{{parent_dir}}/{{branch}}"
+    is_tracked=$(git worktree list | grep -c "\[{{branch}}\]" || true)
 
-    if [ -z "${worktree_path}" ]; then
+    if [ "${is_tracked}" -eq 0 ] && [ ! -d "${worktree_path}" ]; then
         echo "Error: worktree for branch '{{branch}}' does not exist."
         exit 1
     fi
@@ -62,8 +63,15 @@ rm branch=`git branch --show-current` force="":
         (cd "${worktree_path}" && docker compose down 2>/dev/null) || true
     fi
 
-    echo "==> Removing git worktree"
-    git worktree remove "${worktree_path}" --force
+    if [ "${is_tracked}" -gt 0 ]; then
+        echo "==> Removing git worktree"
+        git worktree remove "${worktree_path}" --force
+    fi
+
+    if [ -d "${worktree_path}" ]; then
+        echo "==> Cleaning up leftover directory"
+        rm -rf "${worktree_path}"
+    fi
 
     echo "==> Deleting branch '{{branch}}'"
     if [ "${force}" = "force" ]; then


### PR DESCRIPTION
## Summary
- Fix silent script crash when `grep` finds no match under `set -euo pipefail` — the pipeline exit code killed the script before any error message
- Add orphan directory cleanup: if `git worktree remove` previously removed tracking but left the directory on disk (e.g. locked `.vite/`), `wk::rm` now detects and removes the leftover directory

Closes #84

## Test plan
- [x] `just wk::rm wt_rm_not_deleting_folders force` — successfully cleaned up ghost directory + deleted branch
- [x] `just wk::rm nonexistent_branch` — correctly prints "does not exist" error
- [x] `just wk::rm main` — correctly refuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)