### PR TITLE
fix: use generated VITE_PORT for dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,14 @@
 import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
-export default defineConfig({ plugins: [tailwindcss(), sveltekit()] });
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  return {
+    plugins: [tailwindcss(), sveltekit()],
+    server: {
+      port: Number(env.VITE_PORT || 5173),
+      strictPort: true,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- `vite dev` ignored the `VITE_PORT` variable from `.env` and always bound to default port 5173, causing all worktrees to fight for the same port
- Use Vite's `loadEnv` in `vite.config.ts` to read `.env` before config evaluation and set `server.port`
- Enable `strictPort: true` so port conflicts fail immediately instead of silently incrementing

## Test plan
- [x] Pre-commit hooks pass (prettier, svelte-check, vitest)
- [x] Run `bun scripts/generate-ports.ts --auto` then `bun dev` — verify Vite binds to the generated `VITE_PORT`
- [x] Run `bun dev` with no `.env` — verify it defaults to 5173
- [x] Create a worktree with `just wk::new <branch>` and confirm `bun dev` uses the worktree's unique port

🤖 Generated with [Claude Code](https://claude.com/claude-code)