### PR TITLE
fix: stop Vite dev server before worktree removal and fix branch deletion

### DIFF
--- a/.just/wk.just
+++ b/.just/wk.just
@@ -11,7 +11,7 @@ new branch:
     git fetch origin main
 
     echo "==> Creating worktree at ../{{branch}}"
-    git worktree add "${worktree_path}" -b "{{branch}}" origin/main
+    git worktree add "${worktree_path}" -b "{{branch}}" --no-track origin/main
 
     cd "${worktree_path}"
 

--- a/.just/wk.just
+++ b/.just/wk.just
@@ -42,6 +42,7 @@ rm branch=`git branch --show-current` force="":
     #!/usr/bin/env bash
     set -euo pipefail
     force="{{force}}"
+    original_dir="${PWD}"
 
     if [ "{{branch}}" = "main" ]; then
         echo "Error: refusing to remove 'main'."
@@ -59,9 +60,13 @@ rm branch=`git branch --show-current` force="":
     echo "==> Removing worktree '{{branch}}'"
 
     if [ -d "${worktree_path}" ]; then
+        just wk::_stop_dev "${worktree_path}"
+
         echo "==> Stopping docker containers"
         (cd "${worktree_path}" && docker compose down 2>/dev/null) || true
     fi
+
+    cd "{{parent_dir}}/main"
 
     if [ "${is_tracked}" -gt 0 ]; then
         echo "==> Removing git worktree"
@@ -75,14 +80,14 @@ rm branch=`git branch --show-current` force="":
 
     echo "==> Deleting branch '{{branch}}'"
     if [ "${force}" = "force" ]; then
-        git branch -D "{{branch}}" 2>/dev/null || true
+        git branch -D "{{branch}}"
     else
-        git branch -d "{{branch}}" 2>/dev/null || true
+        git branch -d "{{branch}}"
     fi
 
     echo "==> Worktree '{{branch}}' removed"
 
-    if [ -n "${ZELLIJ_SESSION_NAME:-}" ] && echo "${PWD}" | grep -q "{{branch}}"; then
+    if [ -n "${ZELLIJ_SESSION_NAME:-}" ] && echo "${original_dir}" | grep -q "{{branch}}"; then
         zellij action close-tab
     fi
 
@@ -110,3 +115,40 @@ zellij branch:
         --layout "{{repo_root}}/.zellij/layout.kdl" \
         --cwd "${worktree_path}" \
         --name "{{branch}}"
+
+_stop_dev worktree_path:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    env_file="{{worktree_path}}/.env"
+
+    if [ ! -f "${env_file}" ]; then
+        exit 0
+    fi
+
+    port=$(grep -m1 '^VITE_PORT=' "${env_file}" | cut -d= -f2)
+
+    if [ -z "${port}" ]; then
+        exit 0
+    fi
+
+    echo "==> Stopping dev server on port ${port}"
+    just wk::_kill_port "${port}"
+
+_kill_port port timeout="3":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    pid=$(lsof -ti :{{port}} 2>/dev/null || true)
+
+    if [ -z "${pid}" ]; then
+        exit 0
+    fi
+
+    kill "${pid}" 2>/dev/null || exit 0
+
+    max_ticks=$(( {{timeout}} * 10 ))
+    for (( i=0; i<max_ticks; i++ )); do
+        kill -0 "${pid}" 2>/dev/null || exit 0
+        sleep 0.1
+    done
+
+    kill -9 "${pid}" 2>/dev/null || true

--- a/scripts/lib/is-port-available.ts
+++ b/scripts/lib/is-port-available.ts
@@ -1,0 +1,12 @@
+import { createServer } from 'node:net';
+
+export function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', () => resolve(false));
+    server.listen(port, '0.0.0.0', () => {
+      server.close(() => resolve(true));
+    });
+  });
+}

--- a/scripts/lib/ports.test.ts
+++ b/scripts/lib/ports.test.ts
@@ -3,16 +3,30 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer, type Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('./is-port-available.ts');
+
+import { isPortAvailable } from './is-port-available.ts';
 import {
   BASE_PORTS,
   checkPorts,
   computePorts,
   findAvailableOffset,
   generatePorts,
-  isPortAvailable,
   OFFSET_STEP,
 } from './ports.ts';
+
+const { isPortAvailable: realIsPortAvailable } =
+  await vi.importActual<typeof import('./is-port-available.ts')>('./is-port-available.ts');
+
+function useRealPorts() {
+  vi.mocked(isPortAvailable).mockImplementation(realIsPortAvailable);
+}
+
+function useFakePorts(occupiedPorts: Set<number>) {
+  vi.mocked(isPortAvailable).mockImplementation(async (port: number) => !occupiedPorts.has(port));
+}
 
 describe('computePorts', () => {
   test('offset 0 returns base ports', () => {
@@ -38,6 +52,10 @@ describe('computePorts', () => {
 
 describe('isPortAvailable', () => {
   let server: Server | undefined;
+
+  beforeEach(() => {
+    useRealPorts();
+  });
 
   afterEach(async () => {
     if (server) {
@@ -78,6 +96,10 @@ describe('isPortAvailable', () => {
 describe('checkPorts', () => {
   let servers: Server[] = [];
 
+  beforeEach(() => {
+    useRealPorts();
+  });
+
   afterEach(async () => {
     await Promise.all(servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))));
     servers = [];
@@ -109,78 +131,39 @@ describe('checkPorts', () => {
 });
 
 describe('findAvailableOffset', () => {
-  let servers: Server[] = [];
+  const occupiedPorts = new Set<number>();
 
-  afterEach(async () => {
-    await Promise.all(servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))));
-    servers = [];
+  beforeEach(() => {
+    occupiedPorts.clear();
+    useFakePorts(occupiedPorts);
   });
 
-  async function tryBindPort(port: number): Promise<boolean> {
-    return new Promise((resolve) => {
-      const s = createServer();
-      s.on('error', () => resolve(false));
-      s.listen(port, '0.0.0.0', () => {
-        servers.push(s);
-        resolve(true);
-      });
-    });
-  }
-
   test('skips offsets whose ports are occupied', async () => {
-    const candidates = [40_000, 30_000, 20_000, 10_000];
-    let testStart: number | undefined;
-    for (const offset of candidates) {
-      const port = BASE_PORTS.CONVEX_BACKEND_PORT + offset;
-      if (await tryBindPort(port)) {
-        testStart = offset;
-        break;
-      }
-    }
-    if (testStart === undefined) throw new Error('Could not bind any test port');
+    const blockedPorts = computePorts(10_000);
+    Object.values(blockedPorts).forEach((p) => occupiedPorts.add(p));
 
-    const offset = await findAvailableOffset({ startOffset: testStart });
-    expect(offset).not.toBe(testStart);
+    const offset = await findAvailableOffset({ startOffset: 10_000 });
+    expect(offset).toBe(20_000);
     expect(offset % OFFSET_STEP).toBe(0);
   });
 
   test('returns startOffset when its ports are all free', async () => {
-    const candidates = [50_000, 40_000, 30_000, 20_000];
-    let freeOffset: number | undefined;
-    for (const offset of candidates) {
-      const portsForOffset = computePorts(offset);
-      const { conflicts } = await checkPorts(portsForOffset);
-      if (conflicts.length === 0) {
-        freeOffset = offset;
-        break;
-      }
-    }
-    if (freeOffset === undefined) throw new Error('Could not find a free offset');
-
-    const offset = await findAvailableOffset({ startOffset: freeOffset });
-    expect(offset).toBe(freeOffset);
+    const offset = await findAvailableOffset({ startOffset: 20_000 });
+    expect(offset).toBe(20_000);
   });
 });
 
 describe('generatePorts', () => {
   let tmpDir: string;
   let envPath: string;
-  let servers: Server[] = [];
+  const occupiedPorts = new Set<number>();
 
-  async function tryBindPort(port: number): Promise<boolean> {
-    return new Promise((resolve) => {
-      const s = createServer();
-      s.on('error', () => resolve(false));
-      s.listen(port, '0.0.0.0', () => {
-        servers.push(s);
-        resolve(true);
-      });
-    });
-  }
+  beforeEach(() => {
+    occupiedPorts.clear();
+    useFakePorts(occupiedPorts);
+  });
 
-  afterEach(async () => {
-    await Promise.all(servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))));
-    servers = [];
+  afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
@@ -190,18 +173,9 @@ describe('generatePorts', () => {
     if (existingEnv) writeFileSync(envPath, existingEnv);
   }
 
-  async function findFreeOffset(): Promise<number> {
-    for (const offset of [40_000, 30_000, 20_000, 10_000, 50_000]) {
-      const p = computePorts(offset);
-      const { conflicts } = await checkPorts(p);
-      if (conflicts.length === 0) return offset;
-    }
-    throw new Error('Could not find a free offset for test');
-  }
-
   test('--offset writes ports and derived URLs to .env', async () => {
     setup();
-    const offset = await findFreeOffset();
+    const offset = 10_000;
     const expectedBackend = BASE_PORTS.CONVEX_BACKEND_PORT + offset;
     await generatePorts({ mode: 'offset', offset, envPath });
 
@@ -212,53 +186,36 @@ describe('generatePorts', () => {
 
   test('--offset rejects occupied ports', async () => {
     setup();
-    const candidates = [40_000, 30_000, 20_000, 10_000];
-    let blockedOffset: number | undefined;
-    for (const offset of candidates) {
-      const port = BASE_PORTS.CONVEX_BACKEND_PORT + offset;
-      if (await tryBindPort(port)) {
-        blockedOffset = offset;
-        break;
-      }
-    }
-    if (blockedOffset === undefined) throw new Error('Could not bind any test port');
+    const offset = 10_000;
+    const blockedPort = BASE_PORTS.CONVEX_BACKEND_PORT + offset;
+    occupiedPorts.add(blockedPort);
 
-    const blockedPort = BASE_PORTS.CONVEX_BACKEND_PORT + blockedOffset;
-    await expect(generatePorts({ mode: 'offset', offset: blockedOffset, envPath })).rejects.toThrow(
+    await expect(generatePorts({ mode: 'offset', offset, envPath })).rejects.toThrow(
       new RegExp(String(blockedPort)),
     );
   });
 
   test('--auto finds a free offset and writes to .env', async () => {
     setup();
-    const freeOffset = await findFreeOffset();
-    const result = await generatePorts({ mode: 'auto', envPath, startOffset: freeOffset });
+    const result = await generatePorts({ mode: 'auto', envPath, startOffset: 10_000 });
 
     const content = readFileSync(envPath, 'utf8');
     expect(content).toContain('CONVEX_BACKEND_PORT=');
-    expect(result.offset).toBe(freeOffset);
+    expect(result.offset).toBe(10_000);
   });
 
   test('--auto skips occupied offsets', async () => {
     setup();
-    const candidates = [40_000, 30_000, 20_000, 10_000];
-    let blockedOffset: number | undefined;
-    for (const offset of candidates) {
-      const port = BASE_PORTS.CONVEX_BACKEND_PORT + offset;
-      if (await tryBindPort(port)) {
-        blockedOffset = offset;
-        break;
-      }
-    }
-    if (blockedOffset === undefined) throw new Error('Could not bind any test port');
+    const blockedPorts = computePorts(10_000);
+    Object.values(blockedPorts).forEach((p) => occupiedPorts.add(p));
 
-    const result = await generatePorts({ mode: 'auto', envPath, startOffset: blockedOffset });
-    expect(result.offset).not.toBe(blockedOffset);
+    const result = await generatePorts({ mode: 'auto', envPath, startOffset: 10_000 });
+    expect(result.offset).toBe(20_000);
   });
 
   test('preserves existing .env entries', async () => {
     setup('INSTANCE_NAME=my-instance\nINSTANCE_SECRET=abc123\n');
-    const offset = await findFreeOffset();
+    const offset = 10_000;
     const expectedBackend = BASE_PORTS.CONVEX_BACKEND_PORT + offset;
     await generatePorts({ mode: 'offset', offset, envPath });
 

--- a/scripts/lib/ports.ts
+++ b/scripts/lib/ports.ts
@@ -1,7 +1,8 @@
 import { readdirSync, statSync } from 'node:fs';
-import { createServer } from 'node:net';
 import { join } from 'node:path';
 import { merge, read as readEnv } from './dotenv.ts';
+import { isPortAvailable } from './is-port-available.ts';
+export { isPortAvailable };
 
 export const BASE_PORTS = {
   CONVEX_BACKEND_PORT: 3210,
@@ -110,15 +111,4 @@ export async function generatePorts(
 
   merge(opts.envPath, entries);
   return { offset, entries };
-}
-
-export function isPortAvailable(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = createServer();
-    server.unref();
-    server.on('error', () => resolve(false));
-    server.listen(port, '0.0.0.0', () => {
-      server.close(() => resolve(true));
-    });
-  });
 }


### PR DESCRIPTION
## Summary
- Fixes `.vite/deps_temp_*` leftover directories after `wk::rm` by gracefully killing the Vite dev server before removing the worktree
- Fixes `git branch -d` silently failing when `wk::rm` is run from within the worktree being removed, by cd-ing to the main worktree first
- Adds `_stop_dev` and `_kill_port` private recipes for clean process teardown (SIGTERM + wait + SIGKILL fallback)

## Test plan
- [ ] Create a worktree with `just wk::new test-branch`
- [ ] Start `bun dev` in it (or open via `just wk::new_ui`)
- [ ] Run `just wk::rm test-branch` from within the worktree
- [ ] Verify no leftover directory at `../test-branch`
- [ ] Verify branch `test-branch` is deleted (`git branch` should not list it)
- [ ] Verify zellij tab closes if running inside zellij

🤖 Generated with [Claude Code](https://claude.com/claude-code)